### PR TITLE
[COR-401] Removing `rubocop` gem to address security vulnerabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 .ruby-version
 .yardoc
 .rake_tasks~
-Gemfile.lock
 coverage/*
 doc/*
 log/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next Release
 Your contribution here.
+* [#149](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/149): Add support for script and v3 api_url structure. - [@tfx](https://github.com/tfx).
 
 * [#000](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/000): Brief description here. - [@username](https://github.com/username).
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,9 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 gemspec
 
 group :development do
-  gem 'pry'
-  gem 'rspec'
-  gem 'rubocop'
-  gem 'simplecov'
+  gem "pry"
+  gem "rspec"
+  gem "simplecov"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bigcommerce (1.0.1)
+    bigcommerce (2.0.0)
       faraday (< 3)
       faraday-gzip (< 2)
       hashie (< 6)
@@ -10,31 +10,31 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.2)
+    base64 (0.3.0)
     coderay (1.1.3)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    faraday (2.7.4)
-      faraday-net_http (>= 2.0, < 3.1)
-      ruby2_keywords (>= 0.0.4)
+    faraday (2.13.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
     faraday-gzip (1.0.0)
       faraday (>= 1.0)
       zlib (~> 2.1)
-    faraday-net_http (3.0.2)
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
     hashie (5.0.0)
-    json (2.6.3)
-    jwt (2.7.0)
+    json (2.12.2)
+    jwt (2.10.1)
+      base64
+    logger (1.7.0)
     method_source (1.0.0)
-    parallel (1.23.0)
-    parser (3.2.2.1)
-      ast (~> 2.4.1)
+    net-http (0.6.0)
+      uri
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.8.0)
-    rexml (3.2.5)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -48,31 +48,18 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
-    rubocop (1.50.2)
-      json (~> 2.3)
-      parallel (~> 1.10)
-      parser (>= 3.2.0.0)
-      rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8, < 3.0)
-      rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.28.0, < 2.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.28.0)
-      parser (>= 3.2.1.0)
-    ruby-progressbar (1.13.0)
-    ruby2_keywords (0.0.5)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    unicode-display_width (2.4.2)
+    uri (1.0.3)
     zlib (2.1.1)
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-24
 
 DEPENDENCIES
   bigcommerce!
@@ -80,7 +67,6 @@ DEPENDENCIES
   pry
   rake
   rspec
-  rubocop
   simplecov
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,8 +4,8 @@ PATH
     bigcommerce (1.0.1)
       faraday (< 3)
       faraday-gzip (< 2)
-      hashie (~> 3.4)
-      jwt (~> 1.5.4)
+      hashie (< 6)
+      jwt (< 3)
 
 GEM
   remote: https://rubygems.org/
@@ -21,9 +21,9 @@ GEM
       faraday (>= 1.0)
       zlib (~> 2.1)
     faraday-net_http (3.0.2)
-    hashie (3.6.0)
+    hashie (5.0.0)
     json (2.6.3)
-    jwt (1.5.6)
+    jwt (2.7.0)
     method_source (1.0.0)
     parallel (1.23.0)
     parser (3.2.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,87 @@
+PATH
+  remote: .
+  specs:
+    bigcommerce (1.0.1)
+      faraday (< 3)
+      faraday-gzip (< 2)
+      hashie (~> 3.4)
+      jwt (~> 1.5.4)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    coderay (1.1.3)
+    diff-lcs (1.5.0)
+    docile (1.4.0)
+    faraday (2.7.4)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-gzip (1.0.0)
+      faraday (>= 1.0)
+      zlib (~> 2.1)
+    faraday-net_http (3.0.2)
+    hashie (3.6.0)
+    json (2.6.3)
+    jwt (1.5.6)
+    method_source (1.0.0)
+    parallel (1.23.0)
+    parser (3.2.2.1)
+      ast (~> 2.4.1)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rainbow (3.1.1)
+    rake (13.0.6)
+    regexp_parser (2.8.0)
+    rexml (3.2.5)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
+    rubocop (1.50.2)
+      json (~> 2.3)
+      parallel (~> 1.10)
+      parser (>= 3.2.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.28.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.28.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
+    unicode-display_width (2.4.2)
+    zlib (2.1.1)
+
+PLATFORMS
+  arm64-darwin-21
+
+DEPENDENCIES
+  bigcommerce!
+  bundler
+  pry
+  rake
+  rspec
+  rubocop
+  simplecov
+
+BUNDLED WITH
+   2.3.26

--- a/README.md
+++ b/README.md
@@ -172,5 +172,21 @@ Bigcommerce::System.raw_request(:get, 'time', connection: connection_legacy)
 => #<Faraday::Response:0x007fd4a4063170 ... >>
 ```
 
+### API v3 support
+
+The `Bigcommerce::Script` requires a v3 api url, which can be achieved by adding `version` to the configuration:
+
+```rb
+connection_v3 = Bigcommerce::Connection.build(
+  Bigcommerce::Config.new(
+    store_hash: ENV['BC_STORE_HASH'],
+    client_id: ENV['BC_CLIENT_ID'],
+    access_token: ENV['BC_ACCESS_TOKEN'],
+    version: '3'
+  )
+)
+Bigcommerce::V3::Script.all(connection: connection_v3)
+```
+
 ## Contributing
 See [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -174,15 +174,14 @@ Bigcommerce::System.raw_request(:get, 'time', connection: connection_legacy)
 
 ### API v3 support
 
-The `Bigcommerce::Script` requires a v3 api url, which can be achieved by adding `version` to the configuration:
+The `Bigcommerce::Script` requires a v3 api url. `Bigcommerce::V3::Script` will automatically use the V3 api endpoint instead of V2
 
 ```rb
 connection_v3 = Bigcommerce::Connection.build(
   Bigcommerce::Config.new(
     store_hash: ENV['BC_STORE_HASH'],
     client_id: ENV['BC_CLIENT_ID'],
-    access_token: ENV['BC_ACCESS_TOKEN'],
-    version: '3'
+    access_token: ENV['BC_ACCESS_TOKEN']
   )
 )
 Bigcommerce::V3::Script.all(connection: connection_v3)

--- a/bigcommerce.gemspec
+++ b/bigcommerce.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'bigcommerce/version'
 

--- a/bigcommerce.gemspec
+++ b/bigcommerce.gemspec
@@ -1,27 +1,27 @@
-lib = File.expand_path('lib', __dir__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'bigcommerce/version'
+require "bigcommerce/version"
 
 Gem::Specification.new do |s|
-  s.name = 'bigcommerce'
+  s.name = "bigcommerce"
   s.version = Bigcommerce::VERSION
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.0.0'
-  s.license = 'MIT'
+  s.required_ruby_version = ">= 2.0.0"
+  s.license = "MIT"
 
-  s.authors = ['BigCommerce Engineering']
-  s.homepage = 'https://github.com/bigcommerce/bigcommerce-api-ruby'
-  s.summary = 'Ruby client library for the BigCommerce API'
+  s.authors = ["BigCommerce Engineering"]
+  s.homepage = "https://github.com/bigcommerce/bigcommerce-api-ruby"
+  s.summary = "Ruby client library for the BigCommerce API"
   s.description = s.summary
 
-  s.require_paths = ['lib']
-  s.files = Dir['README.md', 'lib/**/*', 'bigcommerce.gemspec']
+  s.require_paths = ["lib"]
+  s.files = Dir["README.md", "lib/**/*", "bigcommerce.gemspec"]
 
-  s.add_development_dependency 'bundler'
-  s.add_development_dependency 'rake'
+  s.add_development_dependency "bundler"
+  s.add_development_dependency "rake"
 
-  s.add_dependency 'faraday', '< 3'
-  s.add_dependency 'faraday-gzip', '< 2'
-  s.add_dependency 'hashie', '< 6'
-  s.add_dependency 'jwt', '< 3'
+  s.add_dependency "faraday", "< 3"
+  s.add_dependency "faraday-gzip", "< 2"
+  s.add_dependency "hashie", "< 6"
+  s.add_dependency "jwt", "< 3"
 end

--- a/bigcommerce.gemspec
+++ b/bigcommerce.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'
 
-  s.add_dependency 'faraday', '~> 0.11'
-  s.add_dependency 'faraday_middleware', '~> 0.11'
+  s.add_dependency 'faraday', '< 3'
+  s.add_dependency 'faraday-gzip', '< 2'
   s.add_dependency 'hashie', '~> 3.4'
   s.add_dependency 'jwt', '~> 1.5.4'
 end

--- a/bigcommerce.gemspec
+++ b/bigcommerce.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'faraday', '< 3'
   s.add_dependency 'faraday-gzip', '< 2'
-  s.add_dependency 'hashie', '~> 3.4'
-  s.add_dependency 'jwt', '~> 1.5.4'
+  s.add_dependency 'hashie', '< 6'
+  s.add_dependency 'jwt', '< 3'
 end

--- a/lib/bigcommerce.rb
+++ b/lib/bigcommerce.rb
@@ -1,5 +1,5 @@
 require 'hashie'
-require 'faraday_middleware'
+require 'faraday/gzip'
 require 'bigcommerce/version'
 require 'bigcommerce/config'
 require 'bigcommerce/connection'

--- a/lib/bigcommerce/config.rb
+++ b/lib/bigcommerce/config.rb
@@ -8,7 +8,7 @@ module Bigcommerce
       return url if auth == 'legacy'
 
       base = ENV['BC_API_ENDPOINT'].to_s.empty? ? DEFAULTS[:base_url] : ENV['BC_API_ENDPOINT']
-      "#{base}/stores/#{store_hash}/v2"
+      "#{base}/stores/#{store_hash}/v#{version || 2}"
     end
   end
 end

--- a/lib/bigcommerce/config.rb
+++ b/lib/bigcommerce/config.rb
@@ -8,7 +8,7 @@ module Bigcommerce
       return url if auth == 'legacy'
 
       base = ENV['BC_API_ENDPOINT'].to_s.empty? ? DEFAULTS[:base_url] : ENV['BC_API_ENDPOINT']
-      "#{base}/stores/#{store_hash}/v#{version || 2}"
+      "#{base}/stores/#{store_hash}"
     end
   end
 end

--- a/lib/bigcommerce/connection.rb
+++ b/lib/bigcommerce/connection.rb
@@ -13,12 +13,12 @@ module Bigcommerce
         conn.request :json
         conn.headers = HEADERS
         if config.auth == 'legacy'
-          conn.use Faraday::Request::BasicAuthentication, config.username, config.api_key
+          conn.use Faraday::Request::Authorization, config.username, config.api_key
         else
           conn.use Bigcommerce::Middleware::Auth, config
         end
         conn.use Bigcommerce::Middleware::HttpException
-        conn.use FaradayMiddleware::Gzip
+        conn.request :gzip
         conn.adapter Faraday.default_adapter
       end
     end

--- a/lib/bigcommerce/exception.rb
+++ b/lib/bigcommerce/exception.rb
@@ -40,7 +40,7 @@ module Bigcommerce
     }.freeze
 
     def throw_http_exception!(code, env)
-      return unless ERRORS.keys.include? code
+      return unless ERRORS.key? code
       response_headers = {}
       unless env.body.empty?
         response_headers = begin

--- a/lib/bigcommerce/middleware/http_exception.rb
+++ b/lib/bigcommerce/middleware/http_exception.rb
@@ -2,7 +2,7 @@ require 'bigcommerce/exception'
 
 module Bigcommerce
   module Middleware
-    class HttpException < Faraday::Response::Middleware
+    class HttpException < Faraday::Middleware
       include Bigcommerce::HttpErrors
 
       def on_complete(env)

--- a/lib/bigcommerce/resources/content/blog_post.rb
+++ b/lib/bigcommerce/resources/content/blog_post.rb
@@ -23,7 +23,7 @@ module Bigcommerce
     property :count
 
     def self.count(params = {})
-      get 'blog/posts/count', params
+      get 'v2/blog/posts/count', params
     end
   end
 end

--- a/lib/bigcommerce/resources/content/blog_post.rb
+++ b/lib/bigcommerce/resources/content/blog_post.rb
@@ -4,7 +4,7 @@
 
 module Bigcommerce
   class BlogPost < Resource
-    include Bigcommerce::ResourceActions.new uri: 'blog/posts/%d'
+    include Bigcommerce::ResourceActions.new uri: 'v2/blog/posts/%d'
 
     property :id
     property :url

--- a/lib/bigcommerce/resources/content/blog_tag.rb
+++ b/lib/bigcommerce/resources/content/blog_tag.rb
@@ -4,7 +4,7 @@
 
 module Bigcommerce
   class BlogTag < Resource
-    include Bigcommerce::Request.new 'blog/tags'
+    include Bigcommerce::Request.new 'v2/blog/tags'
 
     property :tag
     property :post_ids

--- a/lib/bigcommerce/resources/content/redirect.rb
+++ b/lib/bigcommerce/resources/content/redirect.rb
@@ -15,7 +15,7 @@ module Bigcommerce
     property :url
 
     def self.count(params = {})
-      get 'redirects/count', params
+      get 'v2/redirects/count', params
     end
   end
 end

--- a/lib/bigcommerce/resources/content/redirect.rb
+++ b/lib/bigcommerce/resources/content/redirect.rb
@@ -6,7 +6,7 @@
 
 module Bigcommerce
   class Redirect < Resource
-    include Bigcommerce::ResourceActions.new uri: 'redirects/%d'
+    include Bigcommerce::ResourceActions.new uri: 'v2/redirects/%d'
 
     property :id
     property :count

--- a/lib/bigcommerce/resources/customers/customer.rb
+++ b/lib/bigcommerce/resources/customers/customer.rb
@@ -28,7 +28,7 @@ module Bigcommerce
     property :accepts_marketing
 
     def self.count(params = {})
-      get 'customers/count', params
+      get 'v2/customers/count', params
     end
 
     # Generate a token that can be used to log the customer into the storefront.

--- a/lib/bigcommerce/resources/customers/customer.rb
+++ b/lib/bigcommerce/resources/customers/customer.rb
@@ -7,7 +7,7 @@ require 'securerandom'
 
 module Bigcommerce
   class Customer < Resource
-    include Bigcommerce::ResourceActions.new uri: 'customers/%d'
+    include Bigcommerce::ResourceActions.new uri: 'v2/customers/%d'
 
     property :id
     property :_authentication

--- a/lib/bigcommerce/resources/customers/customer_address.rb
+++ b/lib/bigcommerce/resources/customers/customer_address.rb
@@ -24,11 +24,11 @@ module Bigcommerce
     property :phone
 
     def self.count_all(params = {})
-      get 'customers/addresses/count', params
+      get 'v2/customers/addresses/count', params
     end
 
     def self.count(customer_id, params = {})
-      get "customers/#{customer_id}/addresses/count", params
+      get "v2/customers/#{customer_id}/addresses/count", params
     end
   end
 end

--- a/lib/bigcommerce/resources/customers/customer_address.rb
+++ b/lib/bigcommerce/resources/customers/customer_address.rb
@@ -4,7 +4,7 @@
 
 module Bigcommerce
   class CustomerAddress < Resource
-    include Bigcommerce::SubresourceActions.new uri: 'customers/%d/addresses/%d'
+    include Bigcommerce::SubresourceActions.new uri: 'v2/customers/%d/addresses/%d'
 
     property :id
     property :customer_id

--- a/lib/bigcommerce/resources/customers/customer_group.rb
+++ b/lib/bigcommerce/resources/customers/customer_group.rb
@@ -5,7 +5,7 @@
 
 module Bigcommerce
   class CustomerGroup < Resource
-    include Bigcommerce::ResourceActions.new uri: 'customer_groups/%d'
+    include Bigcommerce::ResourceActions.new uri: 'v2/customer_groups/%d'
 
     property :id
     property :name

--- a/lib/bigcommerce/resources/customers/customer_group.rb
+++ b/lib/bigcommerce/resources/customers/customer_group.rb
@@ -15,7 +15,7 @@ module Bigcommerce
     property :discount_rules
 
     def self.count(params = {})
-      get 'customer_groups/count', params
+      get 'v2/customer_groups/count', params
     end
   end
 end

--- a/lib/bigcommerce/resources/geography/country.rb
+++ b/lib/bigcommerce/resources/geography/country.rb
@@ -5,7 +5,7 @@
 module Bigcommerce
   class Country < Resource
     include Bigcommerce::ResourceActions.new(
-      uri: 'countries/%d',
+      uri: 'v2/countries/%d',
       disable: %i[create update destroy destroy_all]
     )
 

--- a/lib/bigcommerce/resources/geography/country.rb
+++ b/lib/bigcommerce/resources/geography/country.rb
@@ -17,7 +17,7 @@ module Bigcommerce
     property :states
 
     def self.count(params = {})
-      get 'countries/count', params
+      get 'v2/countries/count', params
     end
   end
 end

--- a/lib/bigcommerce/resources/geography/state.rb
+++ b/lib/bigcommerce/resources/geography/state.rb
@@ -5,7 +5,7 @@
 module Bigcommerce
   class State < Resource
     include Bigcommerce::SubresourceActions.new(
-      uri: 'countries/%d/states/%d',
+      uri: 'v2/countries/%d/states/%d',
       disable: %i[create update destroy destroy_all]
     )
 

--- a/lib/bigcommerce/resources/geography/state.rb
+++ b/lib/bigcommerce/resources/geography/state.rb
@@ -16,11 +16,11 @@ module Bigcommerce
     property :country_id
 
     def self.count(country_id, params = {})
-      get "countries/#{country_id}/states/count", params
+      get "v2/countries/#{country_id}/states/count", params
     end
 
     def self.count_all(params = {})
-      get 'countries/states/count', params
+      get 'v2/countries/states/count', params
     end
   end
 end

--- a/lib/bigcommerce/resources/marketing/banner.rb
+++ b/lib/bigcommerce/resources/marketing/banner.rb
@@ -4,7 +4,7 @@
 
 module Bigcommerce
   class Banner < Resource
-    include Bigcommerce::ResourceActions.new uri: 'banners/%d'
+    include Bigcommerce::ResourceActions.new uri: 'v2/banners/%d'
 
     property :id
     property :name

--- a/lib/bigcommerce/resources/marketing/coupon.rb
+++ b/lib/bigcommerce/resources/marketing/coupon.rb
@@ -5,7 +5,7 @@
 
 module Bigcommerce
   class Coupon < Resource
-    include Bigcommerce::ResourceActions.new uri: 'coupons/%d'
+    include Bigcommerce::ResourceActions.new uri: 'v2/coupons/%d'
 
     property :id
     property :name

--- a/lib/bigcommerce/resources/marketing/coupon.rb
+++ b/lib/bigcommerce/resources/marketing/coupon.rb
@@ -24,7 +24,7 @@ module Bigcommerce
     property :shipping_methods
 
     def self.count(params = {})
-      get 'coupons/count', params
+      get 'v2/coupons/count', params
     end
   end
 end

--- a/lib/bigcommerce/resources/marketing/gift_certificates.rb
+++ b/lib/bigcommerce/resources/marketing/gift_certificates.rb
@@ -4,7 +4,7 @@
 
 module Bigcommerce
   class GiftCertificates < Resource
-    include Bigcommerce::ResourceActions.new uri: 'gift_certificates/%d'
+    include Bigcommerce::ResourceActions.new uri: 'v2/gift_certificates/%d'
 
     property :id
     property :customer_id

--- a/lib/bigcommerce/resources/orders/order.rb
+++ b/lib/bigcommerce/resources/orders/order.rb
@@ -69,7 +69,7 @@ module Bigcommerce
     property :count
 
     def self.count(params = {})
-      get 'orders/count', params
+      get 'v2/orders/count', params
     end
   end
 end

--- a/lib/bigcommerce/resources/orders/order.rb
+++ b/lib/bigcommerce/resources/orders/order.rb
@@ -4,7 +4,7 @@
 
 module Bigcommerce
   class Order < Resource
-    include Bigcommerce::ResourceActions.new uri: 'orders/%d'
+    include Bigcommerce::ResourceActions.new uri: 'v2/orders/%d'
 
     property :id
     property :status

--- a/lib/bigcommerce/resources/orders/order_coupon.rb
+++ b/lib/bigcommerce/resources/orders/order_coupon.rb
@@ -5,7 +5,7 @@
 module Bigcommerce
   class OrderCoupon < Resource
     include Bigcommerce::SubresourceActions.new(
-      uri: 'orders/%d/coupons/%d',
+      uri: 'v2/orders/%d/coupons/%d',
       disable: %i[create update destroy destroy_all]
     )
 

--- a/lib/bigcommerce/resources/orders/order_message.rb
+++ b/lib/bigcommerce/resources/orders/order_message.rb
@@ -5,7 +5,7 @@
 module Bigcommerce
   class OrderMessage < Resource
     include Bigcommerce::SubresourceActions.new(
-      uri: 'orders/%d/messages/%d',
+      uri: 'v2/orders/%d/messages/%d',
       disable: %i[create update destroy destroy_all]
     )
 

--- a/lib/bigcommerce/resources/orders/order_product.rb
+++ b/lib/bigcommerce/resources/orders/order_product.rb
@@ -55,11 +55,11 @@ module Bigcommerce
     property :count
 
     def self.count(order_id, params = {})
-      get "orders/#{order_id}/products/count", params
+      get "v2/orders/#{order_id}/products/count", params
     end
 
     def self.count_all(params = {})
-      get 'orders/products/count', params
+      get 'v2/orders/products/count', params
     end
   end
 end

--- a/lib/bigcommerce/resources/orders/order_product.rb
+++ b/lib/bigcommerce/resources/orders/order_product.rb
@@ -5,7 +5,7 @@
 module Bigcommerce
   class OrderProduct < Resource
     include Bigcommerce::SubresourceActions.new(
-      uri: 'orders/%d/products/%d',
+      uri: 'v2/orders/%d/products/%d',
       disable: %i[create update destroy destroy_all]
     )
 

--- a/lib/bigcommerce/resources/orders/order_shipping_address.rb
+++ b/lib/bigcommerce/resources/orders/order_shipping_address.rb
@@ -5,7 +5,7 @@
 module Bigcommerce
   class OrderShippingAddress < Resource
     include Bigcommerce::SubresourceActions.new(
-      uri: 'orders/%d/shipping_addresses/%d',
+      uri: 'v2/orders/%d/shipping_addresses/%d',
       disable: %i[create update destroy destroy_all]
     )
 

--- a/lib/bigcommerce/resources/orders/order_shipping_address.rb
+++ b/lib/bigcommerce/resources/orders/order_shipping_address.rb
@@ -41,11 +41,11 @@ module Bigcommerce
     property :count
 
     def self.count(order_id, params = {})
-      get "orders/#{order_id}/shipping_addresses/count", params
+      get "v2/orders/#{order_id}/shipping_addresses/count", params
     end
 
     def self.count_all(params = {})
-      get 'orders/shipping_addresses/count', params
+      get 'v2/orders/shipping_addresses/count', params
     end
   end
 end

--- a/lib/bigcommerce/resources/orders/order_status.rb
+++ b/lib/bigcommerce/resources/orders/order_status.rb
@@ -6,7 +6,7 @@
 module Bigcommerce
   class OrderStatus < Resource
     include Bigcommerce::ResourceActions.new(
-      uri: 'order_statuses/%d',
+      uri: 'v2/order_statuses/%d',
       disable: %i[create update destroy destroy_all]
     )
 

--- a/lib/bigcommerce/resources/orders/order_tax.rb
+++ b/lib/bigcommerce/resources/orders/order_tax.rb
@@ -5,7 +5,7 @@
 module Bigcommerce
   class OrderTax < Resource
     include Bigcommerce::SubresourceActions.new(
-      uri: 'orders/%d/taxes/%d',
+      uri: 'v2/orders/%d/taxes/%d',
       disable: %i[create update destroy destroy_all]
     )
 

--- a/lib/bigcommerce/resources/orders/shipment.rb
+++ b/lib/bigcommerce/resources/orders/shipment.rb
@@ -21,11 +21,11 @@ module Bigcommerce
     property :count
 
     def self.count(order_id, params = {})
-      get "orders/#{order_id}/shipments/count", params
+      get "v2/orders/#{order_id}/shipments/count", params
     end
 
     def self.count_all(params = {})
-      get 'orders/shipments/count', params
+      get 'v2/orders/shipments/count', params
     end
   end
 end

--- a/lib/bigcommerce/resources/orders/shipment.rb
+++ b/lib/bigcommerce/resources/orders/shipment.rb
@@ -4,7 +4,7 @@
 
 module Bigcommerce
   class Shipment < Resource
-    include Bigcommerce::SubresourceActions.new uri: 'orders/%d/shipments/%d'
+    include Bigcommerce::SubresourceActions.new uri: 'v2/orders/%d/shipments/%d'
 
     property :id
     property :items

--- a/lib/bigcommerce/resources/payments/payment_method.rb
+++ b/lib/bigcommerce/resources/payments/payment_method.rb
@@ -4,7 +4,7 @@
 
 module Bigcommerce
   class PaymentMethod < Resource
-    include Bigcommerce::Request.new 'payments/methods'
+    include Bigcommerce::Request.new 'v2/payments/methods'
 
     property :code
     property :name

--- a/lib/bigcommerce/resources/products/brand.rb
+++ b/lib/bigcommerce/resources/products/brand.rb
@@ -5,7 +5,7 @@
 
 module Bigcommerce
   class Brand < Resource
-    include Bigcommerce::ResourceActions.new uri: 'brands/%d'
+    include Bigcommerce::ResourceActions.new uri: 'v2/brands/%d'
 
     property :id
     property :name

--- a/lib/bigcommerce/resources/products/brand.rb
+++ b/lib/bigcommerce/resources/products/brand.rb
@@ -17,7 +17,7 @@ module Bigcommerce
     property :search_keywords
 
     def self.count(params = {})
-      get 'brands/count', params
+      get 'v2/brands/count', params
     end
   end
 end

--- a/lib/bigcommerce/resources/products/bulk_pricing_rule.rb
+++ b/lib/bigcommerce/resources/products/bulk_pricing_rule.rb
@@ -17,11 +17,11 @@ module Bigcommerce
     property :type_value
 
     def self.count(product_id, params = {})
-      get "products/#{product_id}/discount_rules/count", params
+      get "v2/products/#{product_id}/discount_rules/count", params
     end
 
     def self.count_all(params = {})
-      get 'products/discount_rules/count', params
+      get 'v2/products/discount_rules/count', params
     end
   end
 end

--- a/lib/bigcommerce/resources/products/category.rb
+++ b/lib/bigcommerce/resources/products/category.rb
@@ -23,7 +23,7 @@ module Bigcommerce
     property :url
 
     def self.count(params = {})
-      get 'categories/count', params
+      get 'v2/categories/count', params
     end
   end
 end

--- a/lib/bigcommerce/resources/products/category.rb
+++ b/lib/bigcommerce/resources/products/category.rb
@@ -4,7 +4,7 @@
 
 module Bigcommerce
   class Category < Resource
-    include Bigcommerce::ResourceActions.new uri: 'categories/%d'
+    include Bigcommerce::ResourceActions.new uri: 'v2/categories/%d'
 
     property :id
     property :parent_id

--- a/lib/bigcommerce/resources/products/configurable_field.rb
+++ b/lib/bigcommerce/resources/products/configurable_field.rb
@@ -21,11 +21,11 @@ module Bigcommerce
     property :sort_order
 
     def self.count(product_id, params = {})
-      get "products/#{product_id}/configurable_fields/count", params
+      get "v2/products/#{product_id}/configurable_fields/count", params
     end
 
     def self.count_all(params = {})
-      get 'products/configurable_fields/count', params
+      get 'v2/products/configurable_fields/count', params
     end
   end
 end

--- a/lib/bigcommerce/resources/products/custom_field.rb
+++ b/lib/bigcommerce/resources/products/custom_field.rb
@@ -15,11 +15,11 @@ module Bigcommerce
     property :text
 
     def self.count(product_id, params = {})
-      get "products/#{product_id}/custom_fields/count", params
+      get "v2/products/#{product_id}/custom_fields/count", params
     end
 
     def self.count_all(params = {})
-      get 'products/custom_fields/count', params
+      get 'v2/products/custom_fields/count', params
     end
   end
 end

--- a/lib/bigcommerce/resources/products/google_product_search_mapping.rb
+++ b/lib/bigcommerce/resources/products/google_product_search_mapping.rb
@@ -4,7 +4,7 @@
 
 module Bigcommerce
   class GoogleProductSearchMapping < Resource
-    include Bigcommerce::Request.new 'products/%d/googleproductsearch'
+    include Bigcommerce::Request.new 'v2/products/%d/googleproductsearch'
 
     property :size
     property :color

--- a/lib/bigcommerce/resources/products/option.rb
+++ b/lib/bigcommerce/resources/products/option.rb
@@ -14,7 +14,7 @@ module Bigcommerce
     property :values
 
     def self.count(params = {})
-      get 'options/count', params
+      get 'v2/options/count', params
     end
   end
 end

--- a/lib/bigcommerce/resources/products/option.rb
+++ b/lib/bigcommerce/resources/products/option.rb
@@ -4,7 +4,7 @@
 
 module Bigcommerce
   class Option < Resource
-    include Bigcommerce::ResourceActions.new uri: 'options/%d'
+    include Bigcommerce::ResourceActions.new uri: 'v2/options/%d'
 
     property :id
     property :name

--- a/lib/bigcommerce/resources/products/option_set.rb
+++ b/lib/bigcommerce/resources/products/option_set.rb
@@ -4,7 +4,7 @@
 
 module Bigcommerce
   class OptionSet < Resource
-    include Bigcommerce::ResourceActions.new uri: 'option_sets/%d'
+    include Bigcommerce::ResourceActions.new uri: 'v2/option_sets/%d'
 
     property :id
     property :name

--- a/lib/bigcommerce/resources/products/option_set.rb
+++ b/lib/bigcommerce/resources/products/option_set.rb
@@ -12,7 +12,7 @@ module Bigcommerce
     property :options
 
     def self.count(params = {})
-      get 'option_sets/count', params
+      get 'v2/option_sets/count', params
     end
   end
 end

--- a/lib/bigcommerce/resources/products/option_value.rb
+++ b/lib/bigcommerce/resources/products/option_value.rb
@@ -4,7 +4,7 @@
 
 module Bigcommerce
   class OptionValue < Resource
-    include Bigcommerce::SubresourceActions.new uri: 'options/%d/values/%d'
+    include Bigcommerce::SubresourceActions.new uri: 'v2/options/%d/values/%d'
 
     property :id
     property :option_id

--- a/lib/bigcommerce/resources/products/product.rb
+++ b/lib/bigcommerce/resources/products/product.rb
@@ -4,7 +4,7 @@
 
 module Bigcommerce
   class Product < Resource
-    include Bigcommerce::ResourceActions.new uri: 'products/%d'
+    include Bigcommerce::ResourceActions.new uri: 'v2/products/%d'
 
     property :id
     property :sku

--- a/lib/bigcommerce/resources/products/product.rb
+++ b/lib/bigcommerce/resources/products/product.rb
@@ -91,7 +91,7 @@ module Bigcommerce
     property :count
 
     def self.count(params = {})
-      get 'products/count', params
+      get 'v2/products/count', params
     end
   end
 end

--- a/lib/bigcommerce/resources/products/product_image.rb
+++ b/lib/bigcommerce/resources/products/product_image.rb
@@ -21,11 +21,11 @@ module Bigcommerce
     property :date_created
 
     def self.count(product_id, params = {})
-      get "products/#{product_id}/images/count", params
+      get "v2/products/#{product_id}/images/count", params
     end
 
     def self.count_all(params = {})
-      get 'products/images/count', params
+      get 'v2/products/images/count', params
     end
   end
 end

--- a/lib/bigcommerce/resources/products/product_image.rb
+++ b/lib/bigcommerce/resources/products/product_image.rb
@@ -4,7 +4,7 @@
 
 module Bigcommerce
   class ProductImage < Resource
-    include Bigcommerce::SubresourceActions.new uri: 'products/%d/images/%d'
+    include Bigcommerce::SubresourceActions.new uri: 'v2/products/%d/images/%d'
 
     property :id
     property :count

--- a/lib/bigcommerce/resources/products/product_review.rb
+++ b/lib/bigcommerce/resources/products/product_review.rb
@@ -4,7 +4,7 @@
 
 module Bigcommerce
   class ProductReview < Resource
-    include Bigcommerce::SubresourceActions.new uri: 'products/%d/reviews/%d'
+    include Bigcommerce::SubresourceActions.new uri: 'v2/products/%d/reviews/%d'
 
     property :id
     property :product_id

--- a/lib/bigcommerce/resources/products/product_rule.rb
+++ b/lib/bigcommerce/resources/products/product_rule.rb
@@ -21,11 +21,11 @@ module Bigcommerce
     property :conditions
 
     def self.count(product_id, params = {})
-      get "products/#{product_id}/rules/count", params
+      get "v2/products/#{product_id}/rules/count", params
     end
 
     def self.count_all(params = {})
-      get 'products/rules/count', params
+      get 'v2/products/rules/count', params
     end
   end
 end

--- a/lib/bigcommerce/resources/products/product_rule.rb
+++ b/lib/bigcommerce/resources/products/product_rule.rb
@@ -4,7 +4,7 @@
 
 module Bigcommerce
   class ProductRule < Resource
-    include Bigcommerce::SubresourceActions.new uri: 'products/%d/rules/%d'
+    include Bigcommerce::SubresourceActions.new uri: 'v2/products/%d/rules/%d'
 
     property :id
     property :count

--- a/lib/bigcommerce/resources/products/product_video.rb
+++ b/lib/bigcommerce/resources/products/product_video.rb
@@ -14,11 +14,11 @@ module Bigcommerce
     property :name
 
     def self.count(product_id, params = {})
-      get "products/#{product_id}/videos/count", params
+      get "v2/products/#{product_id}/videos/count", params
     end
 
     def self.count_all(params = {})
-      get 'products/videos/count', params
+      get 'v2/products/videos/count', params
     end
   end
 end

--- a/lib/bigcommerce/resources/products/product_video.rb
+++ b/lib/bigcommerce/resources/products/product_video.rb
@@ -4,7 +4,7 @@
 
 module Bigcommerce
   class ProductVideo < Resource
-    include Bigcommerce::SubresourceActions.new uri: 'products/%d/videos/%s'
+    include Bigcommerce::SubresourceActions.new uri: 'v2/products/%d/videos/%s'
 
     property :id
     property :product_id

--- a/lib/bigcommerce/resources/products/sku.rb
+++ b/lib/bigcommerce/resources/products/sku.rb
@@ -4,7 +4,7 @@
 
 module Bigcommerce
   class Sku < Resource
-    include Bigcommerce::SubresourceActions.new uri: 'products/%d/skus/%d'
+    include Bigcommerce::SubresourceActions.new uri: 'v2/products/%d/skus/%d'
 
     property :id
     property :sku

--- a/lib/bigcommerce/resources/products/sku.rb
+++ b/lib/bigcommerce/resources/products/sku.rb
@@ -25,11 +25,11 @@ module Bigcommerce
     property :count
 
     def self.count_all(params = {})
-      get 'products/skus/count', params
+      get 'v2/products/skus/count', params
     end
 
     def self.count(product_id, params = {})
-      get "products/#{product_id}/skus/count", params
+      get "v2/products/#{product_id}/skus/count", params
     end
   end
 end

--- a/lib/bigcommerce/resources/resource.rb
+++ b/lib/bigcommerce/resources/resource.rb
@@ -6,5 +6,9 @@ module Bigcommerce
   class Resource < Hashie::Trash
     include Hashie::Extensions::MethodAccess
     include Hashie::Extensions::IgnoreUndeclared
+
+    def to_h
+      super.reject { |_, value| value.nil? }
+    end
   end
 end

--- a/lib/bigcommerce/resources/shipping/shipping_method.rb
+++ b/lib/bigcommerce/resources/shipping/shipping_method.rb
@@ -5,7 +5,7 @@
 module Bigcommerce
   class ShippingMethod < Resource
     include Bigcommerce::ResourceActions.new(
-      uri: 'shipping/methods/%d',
+      uri: 'v2/shipping/methods/%d',
       disable: %i[create update destroy destroy_all]
     )
 

--- a/lib/bigcommerce/resources/store/store_information.rb
+++ b/lib/bigcommerce/resources/store/store_information.rb
@@ -4,7 +4,7 @@
 
 module Bigcommerce
   class StoreInfo < Resource
-    include Bigcommerce::Request.new 'store'
+    include Bigcommerce::Request.new 'v2/store'
 
     property :id
     property :logo

--- a/lib/bigcommerce/resources/system/time.rb
+++ b/lib/bigcommerce/resources/system/time.rb
@@ -4,7 +4,7 @@
 
 module Bigcommerce
   class System < Resource
-    include Bigcommerce::Request.new 'time'
+    include Bigcommerce::Request.new 'v2/time'
 
     property :time
 

--- a/lib/bigcommerce/resources/v3/script.rb
+++ b/lib/bigcommerce/resources/v3/script.rb
@@ -1,0 +1,14 @@
+# Scripts
+# Scripts are used to create front-end scripts in Stencil theme
+# Need to use connection version v3
+# https://developer.bigcommerce.com/api/v3/#/reference/scripts/content-scripts/create-a-script
+
+module Bigcommerce
+  module V3
+    class Script < Resource
+      include Bigcommerce::ResourceActions.new uri: 'content/scripts/%s'
+
+      property :data
+    end
+  end
+end

--- a/lib/bigcommerce/resources/v3/script.rb
+++ b/lib/bigcommerce/resources/v3/script.rb
@@ -6,7 +6,7 @@
 module Bigcommerce
   module V3
     class Script < Resource
-      include Bigcommerce::ResourceActions.new uri: 'content/scripts/%s'
+      include Bigcommerce::ResourceActions.new uri: 'v3/content/scripts/%s'
 
       property :data
     end

--- a/lib/bigcommerce/resources/webhooks/webhook.rb
+++ b/lib/bigcommerce/resources/webhooks/webhook.rb
@@ -6,7 +6,7 @@
 module Bigcommerce
   class Webhook < Resource
     include Bigcommerce::ResourceActions.new(
-      uri: 'hooks/%d',
+      uri: 'v2/hooks/%d',
       disable: [:destroy_all]
     )
 

--- a/lib/bigcommerce/version.rb
+++ b/lib/bigcommerce/version.rb
@@ -1,3 +1,3 @@
 module Bigcommerce
-  VERSION = '1.0.1'.freeze
+  VERSION = '2.0.0'.freeze
 end

--- a/spec/bigcommerce/bigcommerce_spec.rb
+++ b/spec/bigcommerce/bigcommerce_spec.rb
@@ -3,6 +3,31 @@ RSpec.describe Bigcommerce do
     api.instance_variable_get('@builder').instance_variable_get('@handlers')
   end
 
+  describe 'version configuration' do
+    context 'default version' do
+      it 'should return the api_url with default version 2' do
+        Bigcommerce.configure do |config|
+          config.access_token = 'jksdgkjbhksjdb'
+          config.client_id = 'negskjgdjkbg'
+          config.store_hash = 'some_store'
+        end
+        expect(Bigcommerce.config.api_url).to include('/v2')
+      end
+    end
+
+    context 'custom version' do
+      it 'should return the api_url with custom version' do
+        Bigcommerce.configure do |config|
+          config.access_token = 'jksdgkjbhksjdb'
+          config.client_id = 'negskjgdjkbg'
+          config.store_hash = 'some_store'
+          config.version = '3'
+        end
+        expect(Bigcommerce.config.api_url).to include('/v3')
+      end
+    end
+  end
+
   it 'should return a faraday object when configured' do
     Bigcommerce.configure do |config|
       config.url = 'http://foobar.com'

--- a/spec/bigcommerce/bigcommerce_spec.rb
+++ b/spec/bigcommerce/bigcommerce_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Bigcommerce do
       end
 
       it 'should have the correct auth middleware' do
-        expect(middleware).to include(Faraday::Request::BasicAuthentication)
+        expect(middleware).to include(Faraday::Request::Authorization)
       end
     end
 
@@ -59,7 +59,7 @@ RSpec.describe Bigcommerce do
 
       expect(Bigcommerce.api.instance_variable_get('@builder')
                 .instance_variable_get('@handlers'))
-                .to include(Faraday::Request::BasicAuthentication)
+                .to include(Faraday::Request::Authorization)
 
       Bigcommerce.configure do |config|
         config.access_token = 'jksdgkjbhksjdb'

--- a/spec/bigcommerce/bigcommerce_spec.rb
+++ b/spec/bigcommerce/bigcommerce_spec.rb
@@ -3,31 +3,6 @@ RSpec.describe Bigcommerce do
     api.instance_variable_get('@builder').instance_variable_get('@handlers')
   end
 
-  describe 'version configuration' do
-    context 'default version' do
-      it 'should return the api_url with default version 2' do
-        Bigcommerce.configure do |config|
-          config.access_token = 'jksdgkjbhksjdb'
-          config.client_id = 'negskjgdjkbg'
-          config.store_hash = 'some_store'
-        end
-        expect(Bigcommerce.config.api_url).to include('/v2')
-      end
-    end
-
-    context 'custom version' do
-      it 'should return the api_url with custom version' do
-        Bigcommerce.configure do |config|
-          config.access_token = 'jksdgkjbhksjdb'
-          config.client_id = 'negskjgdjkbg'
-          config.store_hash = 'some_store'
-          config.version = '3'
-        end
-        expect(Bigcommerce.config.api_url).to include('/v3')
-      end
-    end
-  end
-
   it 'should return a faraday object when configured' do
     Bigcommerce.configure do |config|
       config.url = 'http://foobar.com'

--- a/spec/bigcommerce/unit/resources/v3/script_spec.rb
+++ b/spec/bigcommerce/unit/resources/v3/script_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Bigcommerce::V3::Script do
+  before(:each) { @script = Bigcommerce::V3::Script }
+
+  describe '.all' do
+    it 'should hit the correct path' do
+      expect(@script).to receive(:get).with(@script.path.build, {})
+      @script.all
+    end
+  end
+end


### PR DESCRIPTION
#### What?

We decided to drop the `rubocop` gem since one of its dependencies `rexml` introduced security vulnerabilities
<img width="1408" alt="Screenshot 2025-06-02 at 14 24 53" src="https://github.com/user-attachments/assets/a23fcbf6-7049-42a3-a215-bc8cbc4df1e5" />

We plan to eventually stop using this fork, so we won't replace `rubocop` with `standard` here.